### PR TITLE
Replace centered alignment with left alignment

### DIFF
--- a/contents/css/main.css
+++ b/contents/css/main.css
@@ -41,26 +41,20 @@ pre {
 
 h1 {
   font-size: 2em;
-  margin-bottom: 1em;
 }
 
 h2 {
   font-size: 1.2em;
-  font-weight: 400;
   line-height: 1.43;
-  margin-bottom: 1.35em;
 }
 
 h3 {
-  text-align: center;
-  font-weight: 400;
   font-size: 1.4em;
   margin-top: 1.8em;
-  margin-bottom: 0.8em;
 }
 
 ol, ul {
-  margin: 0 1.4em 1.4em 4em;
+  margin: 0 1.4em 1.4em 1.4em;
 }
 
 li {
@@ -87,7 +81,6 @@ hr {
 
 .header h1 {
   font-size: 2.6em;
-  text-align: center;
   font-weight: 700;
   margin: 0;
 }
@@ -105,14 +98,12 @@ hr {
   font-variant: small-caps;
   text-transform: lowercase;
   text-rendering: auto;
-  text-align: center;
   font-weight: 400;
   letter-spacing: 1px;
 }
 
 .header .description {
   font-size: 1.2em;
-  text-align: center;
   margin-top: -0.3em;
 }
 
@@ -133,7 +124,6 @@ footer {
 }
 
 .header .nav, footer .nav {
-  text-align: center;
   margin-top: 0.5em;
   margin-bottom: 0.5em;
 }
@@ -148,11 +138,9 @@ footer .about {
   border-top: 1px dashed #d2d2d2;
   padding: 2.2em 3em;
   font-size: 0.95em;
-  text-align: center;
 }
 
 footer .copy {
-  text-align: center;
   font-size: 0.8em;
   margin-top: 1em;
 }
@@ -172,7 +160,6 @@ footer .copy, footer .copy a {
 }
 
 .article header h2 {
-  text-align: center;
   font-weight: 400;
   margin: 0.8em 0;
   font-size: 1.4em;
@@ -183,7 +170,6 @@ footer .copy, footer .copy a {
 }
 
 .article header .date {
-  text-align: center;
   font-size: 0.8em;
   margin-top: -0.7em;
 }
@@ -263,7 +249,6 @@ footer .copy, footer .copy a {
   font-weight: 400;
   text-rendering: auto;
   letter-spacing: 1px;
-  text-align: center;
 }
 
 .archive .month-label {

--- a/templates/article.jade
+++ b/templates/article.jade
@@ -16,9 +16,6 @@ block header
   hr
   h1.article-title
     a(href=locals.url + '/index.html')= page.title
-  p.author
-    | #{ "Written by " }
-    mixin author(page.metadata.author)
 
 block content
   article.article


### PR DESCRIPTION
Make the site easier to read by using a left alignment.
That CSS that shipped with Wintersmith made the blog feel
like an old newspaper. This is not what I had originally intended.